### PR TITLE
978: Support gzip-compressed output files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The project includes a small data set in the `sample_csv` directory for test usa
 | AWS_REGION           | "eu-west-1"                                             | The AWS region to use.
 | KAFKA_CONSUMER_GROUP | "transform-request"                                     | The name of the Kafka group to read messages from.
 | KAFKA_CONSUMER_TOPIC | "transform-request"                                     | The name of the Kafka topic to read messages from.
+| USE_GZIP             | false                                                   | Whether to apply gzip compression to the output file and set `Content-Encoding: gzip` header on downloads.
 
 ### Contributing
 

--- a/config/transformer.go
+++ b/config/transformer.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/ONSdigital/go-ns/log"
+	"strconv"
 )
 
 const bindAddrKey = "BIND_ADDR"
@@ -12,6 +13,7 @@ const kafkaConsumerGroup = "KAFKA_CONSUMER_GROUP"
 const kafkaConsumerTopic = "KAFKA_CONSUMER_TOPIC"
 const awsRegionKey = "AWS_REGION"
 const hierarchyEndpoint = "HIERARCHY_ENDPOINT"
+const useGzipCompression = "USE_GZIP"
 
 const HIERACHY_ID_PLACEHOLDER = "{hierarchy_id}"
 
@@ -32,6 +34,9 @@ var KafkaConsumerTopic = "transform-request"
 
 // HierarchyEndpoint the url of the metadata api hierarchy endpoint.
 var HierarchyEndpoint = "http://localhost:20099/hierarchies/" + HIERACHY_ID_PLACEHOLDER
+
+// UseGzipCompression determines whether files should be compressed when uploaded to S3 and served with `Content-Encoding: gzip` header.
+var UseGzipCompression = false
 
 func init() {
 	if bindAddrEnv := os.Getenv(bindAddrKey); len(bindAddrEnv) > 0 {
@@ -58,6 +63,14 @@ func init() {
 		HierarchyEndpoint = hierarchyEndpointEnv
 	}
 
+	if useGzipCompressionEnv := os.Getenv(useGzipCompression); len(useGzipCompressionEnv) > 0 {
+		var err error
+		UseGzipCompression, err = strconv.ParseBool(useGzipCompressionEnv)
+		if err != nil {
+			panic("Invalid boolean value for " + useGzipCompression + ": " + useGzipCompressionEnv)
+		}
+	}
+
 }
 
 func Load() {
@@ -69,5 +82,6 @@ func Load() {
 		kafkaConsumerGroup: KafkaConsumerGroup,
 		kafkaConsumerTopic: KafkaConsumerTopic,
 		hierarchyEndpoint:  HierarchyEndpoint,
+		useGzipCompression: UseGzipCompression,
 	})
 }

--- a/scripts/codedeploy/application-start.sh
+++ b/scripts/codedeploy/application-start.sh
@@ -17,6 +17,7 @@ source $CONFIG && docker run -d                    \
   --env=KAFKA_CONSUMER_GROUP=$KAFKA_CONSUMER_GROUP \
   --env=KAFKA_CONSUMER_TOPIC=$KAFKA_CONSUMER_TOPIC \
   --env=HIERARCHY_ENDPOINT=$HIERARCHY_ENDPOINT     \
+  --env=USE_GZIP=$USE_GZIP                         \
   --name=dp-dd-csv-transformer                     \
   --net=$DOCKER_NETWORK                            \
   --restart=always                                 \


### PR DESCRIPTION
### What

Adds support for applying gzip compression to output files and setting the `Content-Encoding` header on the S3 file so that browsers transparently apply decompression after download. This is controlled by an environment variable and off by default while we investigate compatibility and effects on performance etc.

### How to review

`make debug` and check it all works ok. Should be transparent to the job creator etc.

### Who can review

Anyone but me.