### PR TITLE
Close the GzipWriter to ensure all bytes are flushed.

### DIFF
--- a/ons_aws/client.go
+++ b/ons_aws/client.go
@@ -47,7 +47,9 @@ func (cli *Service) SaveFile(requestID string, reader io.Reader, s3url S3URL) er
 		pipeReader, pipeWriter := io.Pipe()
 		go func() {
 			log.DebugC(requestID, "Compressing output on-the-fly", nil)
-			bytesWritten, err := io.Copy(gzip.NewWriter(pipeWriter), reader)
+			gzipWriter := gzip.NewWriter(pipeWriter)
+			defer gzipWriter.Close()
+			bytesWritten, err := io.Copy(gzipWriter, reader)
 			if err != nil {
 				log.ErrorC(requestID, err, nil)
 				pipeWriter.CloseWithError(err)


### PR DESCRIPTION
### What

Close the GzipWriter to ensure all bytes are flushed. Fixes bug with some files being truncated.

### How to review

Eyeball.

### Who can review

Anyone but me.